### PR TITLE
Check response for single record

### DIFF
--- a/MockarooDataGenerator/Mockaroo/MockClient.cs
+++ b/MockarooDataGenerator/Mockaroo/MockClient.cs
@@ -66,6 +66,10 @@ namespace LinkeD365.MockDataGen
             {
                 var response = client.SendAsync(request).Result;
                 responseContent = response.Content.ReadAsStringAsync().Result;
+                if (!responseContent.StartsWith("[") && !responseContent.EndsWith("]"))
+                {
+                    responseContent = "[" + responseContent + "]";
+                }
 
                 if (response.StatusCode != HttpStatusCode.OK)
                 {


### PR DESCRIPTION
When returning just a single record the response from Mockaroo is not an array and the plugin returns and error.  Check the response and update is as an array if only a single record is returned.