### PR TITLE
Fixed Values not included

### DIFF
--- a/MockarooDataGenerator/MockDataGenCtl.cs
+++ b/MockarooDataGenerator/MockDataGenCtl.cs
@@ -199,7 +199,7 @@ namespace LinkeD365.MockDataGen
                     };
 
                     foreach (List<ExpandoObject> subList in SplitList(response))
-                        entityCollection.Entities.AddRange(CreateEntityList(subList, entityCollection.EntityName, maps));
+                        entityCollection.Entities.AddRange(CreateEntityList(subList, entityCollection.EntityName, selectedMaps.ToList<SimpleRow>()));
 
                     e.Result = entityCollection;
                 },


### PR DESCRIPTION
When generating records that have Fixed Values those values were not included in the entity collection.  The filtered map which generates the Mockaroo request was being passed to the entity collection creation code instead of the full map set which included the fixed values.