### PR TITLE
trim lookup name before search

### DIFF
--- a/MockarooDataGenerator/MockDataGenCtl.Methods.Data.cs
+++ b/MockarooDataGenerator/MockDataGenCtl.Methods.Data.cs
@@ -140,7 +140,7 @@ namespace LinkeD365.MockDataGen
                                     map.ParentTable,
                                     randomLookup.AllValues
                                         .First(
-                                            lup => lup.Name ==
+                                            lup => lup.Name.Trim() ==
                                                         propertyValues[
                                                             map.LogicalName].ToString(
                                                             ))
@@ -366,7 +366,7 @@ namespace LinkeD365.MockDataGen
                                     map.ParentTable,
                                     randomLookup.AllValues
                                         .First(
-                                            lup => lup.Name ==
+                                            lup => lup.Name.Trim() ==
                                                         propertyValues[
                                                             map.LogicalName].ToString(
                                                             ))


### PR DESCRIPTION
When lookup names with a leading or trailing space are sent to Mockaroo they are automatically trimmed upon their return.  This was causing a bug during the comparison of the original lookup names to the ones returned from Mockaroo.  Added a Trim function to ensure that the search was valid for these records.